### PR TITLE
Proversity/add tests for badges

### DIFF
--- a/badger/badger.py
+++ b/badger/badger.py
@@ -135,11 +135,25 @@ class BadgerXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
         """
         return self.get_xblock_settings().get('BADGR_API_TOKEN', '')
 
+    @property
+    def api_url(self):
+        """
+        Returns the URL of the Badgr Server from the Settings Service.
+        The URL hould be set in both lms/cms env.json files inside XBLOCK_SETTINGS.
+        Example:
+            "XBLOCK_SETTINGS": {
+                "BadgerXBlock": {
+                    "BADGR_BASE_URL": "YOUR URL  GOES HERE"
+                }
+            },
+        """
+        return self.get_xblock_settings().get('BADGR_BASE_URL' '')
+
     def get_list_of_issuers(self):
         """
         Get a list of issuers from badgr.proversity.org
         """
-        issuer_list = requests.get("http://badgr.proversity.org/v1/issuer/issuers",  headers={'Authorization': 'token ' +  str(self.api_token)})
+        issuer_list = requests.get('{}/v1/issuer/issuers'.format(self.api_url),  headers={'Authorization': 'token {}'.format(self.api_token)})
         return issuer_list.json()
 
     def resource_string(self, path):

--- a/badger/badger.py
+++ b/badger/badger.py
@@ -233,7 +233,8 @@ class BadgerXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
             'award_message': self.award_message,
             'motivation_message': self.motivation_message,
             'course_id':  str(self.runtime.course_id),
-            'badgrApiToken': self.api_token
+            'badgrApiToken': self.api_token,
+            'badge_slug': self.badge_slug
         })
 
         return frag
@@ -245,7 +246,6 @@ class BadgerXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
         """
         frag = Fragment()
         context = {'fields': []}
-        issuer_list = self.get_list_of_issuers()
         
         # Build a list of all the fields that can be edited:
         for field_name in self.editable_fields:

--- a/badger/badger.py
+++ b/badger/badger.py
@@ -136,9 +136,10 @@ class BadgerXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
         return self.get_xblock_settings().get('BADGR_API_TOKEN', '')
 
     def get_list_of_issuers(self):
-
+        """
+        Get a list of issuers from badgr.proversity.org
+        """
         issuer_list = requests.get("http://badgr.proversity.org/v1/issuer/issuers",  headers={'Authorization': 'token ' +  str(self.api_token)})
-
         return issuer_list.json()
 
     def resource_string(self, path):

--- a/badger/badger.py
+++ b/badger/badger.py
@@ -219,8 +219,7 @@ class BadgerXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
             'assertion_url': self.assertion_url,
             'description': self.description,
             'criteria': self.criteria,
-            'award_message': self.award_message,
-            
+            'award_message': self.award_message
         }
 
         frag = Fragment(loader.render_django_template("static/html/badger.html", context).format(self=self))

--- a/badger/badger.py
+++ b/badger/badger.py
@@ -210,9 +210,6 @@ class BadgerXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
         else:
             user = User.objects.get(username=self.current_user_key)
 
-        print "*^*^*", self.get_list_of_issuers()
-
-
         context = {
             'received_award': self.received_award,
             'check_earned': self.check_earned,
@@ -248,7 +245,6 @@ class BadgerXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
         frag = Fragment()
         context = {'fields': []}
         issuer_list = self.get_list_of_issuers()
-        print "LENGTH", len(issuer_list)
         
         # Build a list of all the fields that can be edited:
         for field_name in self.editable_fields:

--- a/badger/static/html/badger.html
+++ b/badger/static/html/badger.html
@@ -1,4 +1,5 @@
 <div class="badger_block" id="{{section_title}}">
+
 	{% if received_award and check_earned%}
 		<p class='badger-award'> {{award_message}} <a href="{{assertion_url}}">View the verified badge here.</a> </p>
 		<table width="100%" style="border: none;">
@@ -23,5 +24,6 @@
 		<a href="#" id="check-for-badge" class="btn-gradient cyan block">Click to see if you have earned a badge.</a>
 	{% endif %}
  <div class='badge-loader' tabindex="1000" role="dialog"></div>
+ <div id="results"></div>
  <div id="lean_overlay" style="display: block; opacity: 1; display:none; z-index:3;"></div>
 </div>

--- a/badger/static/html/badger_edit.html
+++ b/badger/static/html/badger_edit.html
@@ -2,12 +2,6 @@
 <div class="editor-with-buttons">
   <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
     <ul class="list-input settings-list">
-    <li>
-      <select id="issuers-badgr">
-        
-
-      </select>
-    </li>
       {% for field in fields %}
         <li
           class="field comp-setting-entry metadata_entry {% if field.is_set %}is-set{% endif %}"

--- a/badger/static/html/badger_edit.html
+++ b/badger/static/html/badger_edit.html
@@ -2,6 +2,12 @@
 <div class="editor-with-buttons">
   <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
     <ul class="list-input settings-list">
+    <li>
+      <select id="issuers-badgr">
+        
+
+      </select>
+    </li>
       {% for field in fields %}
         <li
           class="field comp-setting-entry metadata_entry {% if field.is_set %}is-set{% endif %}"

--- a/badger/static/js/src/badger.js
+++ b/badger/static/js/src/badger.js
@@ -6,6 +6,7 @@ function BadgerXBlock(runtime, element, data) {
     var section_title = data.section_title;
     var pass_mark = data.pass_mark;
     var award_message = data.award_message;
+    var badge_slug = data.badge_slug;
     var motivation_message = data.motivation_message;
     var handlerUrl = runtime.handlerUrl(element, 'new_award_badge');
     var noAwardUrl = runtime.handlerUrl(element, 'no_award_received');
@@ -29,7 +30,8 @@ function BadgerXBlock(runtime, element, data) {
                         $('.badge-loader').hide();
                         $('#lean_overlay').hide();
                         $('#check-for-badge').remove();
-                        $('#results').html("<div>Oops! We have encountered an error, the badge does not exist. Please contact your support administrator."+
+                        $('#results').html("<div>Oops! We have encountered an error, the badge " + 
+                        '"' +  badge_slug + '"' +  " does not exist. Please contact your support administrator."+
                         "</div>"); // add the error to the dom
                         console.log(xhr.status + ": " + xhr.responseText); // provide a bit more info about the error to the console
                     }
@@ -53,7 +55,11 @@ function BadgerXBlock(runtime, element, data) {
         } else {
             $('.badge-loader').hide();
             $('#lean_overlay').hide();
-            alert('The modlue named ' + '"'+ section_title + '"' + ' does not exist in the Grades Report! Please check you have specified the correct module name for this badge.')
+            alert(
+                'The modlue named ' + '"'+ section_title + '"' 
+                + ' does not exist in the Grades Report! Please check you have' 
+                + ' specified the correct module name for this badge.'
+            )
         }
     }
 

--- a/badger/static/js/src/badger.js
+++ b/badger/static/js/src/badger.js
@@ -12,13 +12,9 @@ function BadgerXBlock(runtime, element, data) {
 
     function getGrades(data) {
         var section_scores = data['section_scores'];
-        console.log(section_title)
         if (section_scores.hasOwnProperty(section_title)) {
             var this_section = section_scores[String(section_title)];
-
             var section_title_id = '#' + section_title
-            console.log(this_section, section_scores)
-            console.log("HI", this_section)
             if ( parseFloat(this_section) >= pass_mark) {
                 $.ajax({
                     type: "POST",

--- a/badger/static/js/src/badger.js
+++ b/badger/static/js/src/badger.js
@@ -29,7 +29,8 @@ function BadgerXBlock(runtime, element, data) {
                         $('.badge-loader').hide();
                         $('#lean_overlay').hide();
                         $('#check-for-badge').remove();
-                        $('#results').html("<div>Oops! We have encountered an error, please check that the badge exists and the correct name has been specified.</div>"); // add the error to the dom
+                        $('#results').html("<div>Oops! We have encountered an error, the badge does not exist. Please contact your support administrator."+
+                        "</div>"); // add the error to the dom
                         console.log(xhr.status + ": " + xhr.responseText); // provide a bit more info about the error to the console
                     }
                 });

--- a/badger/static/js/src/badger.js
+++ b/badger/static/js/src/badger.js
@@ -12,54 +12,25 @@ function BadgerXBlock(runtime, element, data) {
 
     function getGrades(data) {
         var section_scores = data['section_scores'];
+        console.log(section_title)
         var this_section = section_scores[String(section_title)];
         var section_title_id = '#' + section_title
+        console.log(this_section, section_scores)
+        console.log("HI", this_section)
         if ( parseFloat(this_section) >= pass_mark) {
             $.ajax({
-            type: "POST",
-            url: handlerUrl,
-            data:JSON.stringify({"name": "badger"}),
-            success: function(json) {
-                $('.badge-loader').hide();
-                $('#lean_overlay').hide();
-                // var $badge = $('<p class="badger-award"> You have received a badge. <a href="' + 
-                //                 json['asertion_url'] +
-                //                 '">View the verified badge here.</a> </p> <img id="image-url" src="' +
-                //                 json['image_url'] + 
-                //                 '" style="width:250px;height:250px;">');
-                // $(section_title_id).append($badge);
-
-                var $badge = $( '<p class="badger-award"> You have received a badge. <a href="' + 
-                                 json['asertion_url'] +
-                                '">View the verified badge here.</a>' +
-                            '<table width="100%" style="border: none;">' + 
-                                '<tbody>' +
-                                    '<tr style="border: none;">' + 
-                                    '<td style="border: none;" width="70%">' +
-                                        '<p><strong>Description</strong></p>' + 
-                                        '<p>' +
-                                            json['description'] +
-                                        '</p>' + 
-                                        '<p><strong>Criteria</strong></p>' + 
-                                            '<p>In order to earn this badge, participants must:</p>' + 
-                                            '<p>'+ 
-                                                json['criteria'] + 
-                                            '</p>' + 
-                                    '</td>'+
-                                    '<td style="vertical-align: middle; border: none;" width="30%">' + 
-                                        '<img src=' + json['image_url'] + 'style="width:250px;height:250px;">' +
-                                    '</td>' + 
-                                    '</tr>' +
-                                '</tbody>' + 
-                            '</table>');
-
-                $(section_title_id).append($badge);
-
-
-                $('#check-for-badge').remove();
+                type: "POST",
+                url: handlerUrl,
+                data:JSON.stringify({"name": "badger"}),
+                success: function(json) {
+                        location.reload();
+                },
+                error : function(xhr,errmsg,err) {
+                    $('#results').html("<div class='alert-box alert radius' data-alert>Oops! We have encountered an error: "+errmsg+
+                    " <a href='#' class='close'>&times;</a></div>"); // add the error to the dom
+                    console.log(xhr.status + ": " + xhr.responseText); // provide a bit more info about the error to the console
                 }
             });
-
         }
         else {
             $.ajax({

--- a/badger/static/js/src/badger.js
+++ b/badger/static/js/src/badger.js
@@ -22,6 +22,7 @@ function BadgerXBlock(runtime, element, data) {
                     url: handlerUrl,
                     data:JSON.stringify({"name": "badger"}),
                     success: function(json) {
+                            // Just reload the page, the correct html with the badge will be displayed
                             location.reload();
                     },
                     error : function(xhr,errmsg,err) {

--- a/badger/static/js/src/badger.js
+++ b/badger/static/js/src/badger.js
@@ -26,8 +26,10 @@ function BadgerXBlock(runtime, element, data) {
                             location.reload();
                     },
                     error : function(xhr,errmsg,err) {
-                        $('#results').html("<div class='alert-box alert radius' data-alert>Oops! We have encountered an error: "+errmsg+
-                        " <a href='#' class='close'>&times;</a></div>"); // add the error to the dom
+                        $('.badge-loader').hide();
+                        $('#lean_overlay').hide();
+                        $('#check-for-badge').remove();
+                        $('#results').html("<div>Oops! We have encountered an error, please check that the badge exists and the correct name has been specified.</div>"); // add the error to the dom
                         console.log(xhr.status + ": " + xhr.responseText); // provide a bit more info about the error to the console
                     }
                 });

--- a/badger/static/js/src/badger.js
+++ b/badger/static/js/src/badger.js
@@ -12,6 +12,7 @@ function BadgerXBlock(runtime, element, data) {
 
     function getGrades(data) {
         var section_scores = data['section_scores'];
+        // Check that the section name specified in Xblock exists in Grades report
         if (section_scores.hasOwnProperty(section_title)) {
             var this_section = section_scores[String(section_title)];
             var section_title_id = '#' + section_title
@@ -62,7 +63,6 @@ function BadgerXBlock(runtime, element, data) {
         $.ajax({
             type: "GET",
             url: my_url,
-            // data: JSON.stringify({"username": user}),
             success: getGrades
         });
     });

--- a/badger/static/js/src/badger.js
+++ b/badger/static/js/src/badger.js
@@ -13,39 +13,46 @@ function BadgerXBlock(runtime, element, data) {
     function getGrades(data) {
         var section_scores = data['section_scores'];
         console.log(section_title)
-        var this_section = section_scores[String(section_title)];
-        var section_title_id = '#' + section_title
-        console.log(this_section, section_scores)
-        console.log("HI", this_section)
-        if ( parseFloat(this_section) >= pass_mark) {
-            $.ajax({
+        if (section_scores.hasOwnProperty(section_title)) {
+            var this_section = section_scores[String(section_title)];
+
+            var section_title_id = '#' + section_title
+            console.log(this_section, section_scores)
+            console.log("HI", this_section)
+            if ( parseFloat(this_section) >= pass_mark) {
+                $.ajax({
+                    type: "POST",
+                    url: handlerUrl,
+                    data:JSON.stringify({"name": "badger"}),
+                    success: function(json) {
+                            location.reload();
+                    },
+                    error : function(xhr,errmsg,err) {
+                        $('#results').html("<div class='alert-box alert radius' data-alert>Oops! We have encountered an error: "+errmsg+
+                        " <a href='#' class='close'>&times;</a></div>"); // add the error to the dom
+                        console.log(xhr.status + ": " + xhr.responseText); // provide a bit more info about the error to the console
+                    }
+                });
+            }
+            else {
+                $.ajax({
                 type: "POST",
-                url: handlerUrl,
+                url: noAwardUrl,
                 data:JSON.stringify({"name": "badger"}),
                 success: function(json) {
-                        location.reload();
-                },
-                error : function(xhr,errmsg,err) {
-                    $('#results').html("<div class='alert-box alert radius' data-alert>Oops! We have encountered an error: "+errmsg+
-                    " <a href='#' class='close'>&times;</a></div>"); // add the error to the dom
-                    console.log(xhr.status + ": " + xhr.responseText); // provide a bit more info about the error to the console
-                }
-            });
-        }
-        else {
-            $.ajax({
-            type: "POST",
-            url: noAwardUrl,
-            data:JSON.stringify({"name": "badger"}),
-            success: function(json) {
-                $('.badge-loader').hide();
-                $('#lean_overlay').hide();
-                var $motivation = $('<p class="badger-motivation">' 
-                + motivation_message + '</p>' );
-                $('.badger_block').append($motivation);
-                $('#check-for-badge').remove();
-                }
-            });
+                    $('.badge-loader').hide();
+                    $('#lean_overlay').hide();
+                    var $motivation = $('<p class="badger-motivation">' 
+                    + motivation_message + '</p>' );
+                    $('.badger_block').append($motivation);
+                    $('#check-for-badge').remove();
+                    }
+                });
+            }
+        } else {
+            $('.badge-loader').hide();
+            $('#lean_overlay').hide();
+            alert('The modlue named ' + '"'+ section_title + '"' + ' does not exist in the Grades Report! Please check you have specified the correct module name for this badge.')
         }
     }
 

--- a/badger/static/js/src/badger_edit.js
+++ b/badger/static/js/src/badger_edit.js
@@ -1,10 +1,15 @@
 /* Javascript for StudioEditableXBlockMixin. */
-function StudioEditableXBlockMixin(runtime, element) {
+function StudioEditableXBlockMixin(runtime, element, data) {
     "use strict";
     
     var fields = [];
     var tinyMceAvailable = (typeof $.fn.tinymce !== 'undefined'); // Studio includes a copy of tinyMCE and its jQuery plugin
     var datepickerAvailable = (typeof $.fn.datepicker !== 'undefined'); // Studio includes datepicker jQuery plugin
+
+    var badgrApiToken = data.badgrApiToken;
+    console.log("hi", data.badgrApiToken);
+
+    $('#dropdownl').append('<option value="unique-issuer">' + 'khda'+ '</option>')
 
     $(element).find('.field-data-control').each(function() {
         var $field = $(this);

--- a/badger/static/js/src/badger_edit.js
+++ b/badger/static/js/src/badger_edit.js
@@ -5,11 +5,7 @@ function StudioEditableXBlockMixin(runtime, element, data) {
     var fields = [];
     var tinyMceAvailable = (typeof $.fn.tinymce !== 'undefined'); // Studio includes a copy of tinyMCE and its jQuery plugin
     var datepickerAvailable = (typeof $.fn.datepicker !== 'undefined'); // Studio includes datepicker jQuery plugin
-
     var badgrApiToken = data.badgrApiToken;
-    console.log("hi", data.badgrApiToken);
-
-    $('#dropdownl').append('<option value="unique-issuer">' + 'khda'+ '</option>')
 
     $(element).find('.field-data-control').each(function() {
         var $field = $(this);

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='badger-xblock',
-    version='0.1',
+    version='0.2.0',
     description='badger XBlock',   # TODO: write a better description.
     license='UNKNOWN',          # TODO: choose a license: 'AGPL v3' and 'Apache 2.0' are popular.
     packages=[


### PR DESCRIPTION
@nicovanniekerk, in order for the badger API token to be availble to the BadgerXblock, we need to set the following in both lms/cms env.json files inside XBLOCK_SETTINGS. This has been added so that we can populate the dropdowns in studio with the issuers available on badgr.proversity.org and their associated badges. This is for future development. This specific PR is however for improved error handling for badgerXblokc. 
```
            "XBLOCK_SETTINGS": {
                "BadgerXBlock": {
                    "BADGR_API_TOKEN": "YOUR API KEY GOES HERE"
                }
            },
```